### PR TITLE
Metrics endpoint implemented.

### DIFF
--- a/src/main/java/com/springboot/connectmate/controllers/MetricController.java
+++ b/src/main/java/com/springboot/connectmate/controllers/MetricController.java
@@ -1,12 +1,16 @@
 package com.springboot.connectmate.controllers;
 
+import com.springboot.connectmate.dtos.Insight.InsightDTO;
+import com.springboot.connectmate.dtos.Metric.ConnectMetricDTO;
 import com.springboot.connectmate.dtos.Metric.MetricDTO;
+import com.springboot.connectmate.enums.InsightStatus;
 import com.springboot.connectmate.services.MetricService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -40,5 +44,19 @@ public class MetricController {
     @GetMapping("/agents")
     public List<MetricDTO> getContactCenterMetrics(){
         return metricService.getContactCenterMetrics();
+    }
+
+    // Get all metrics for a single agent.
+    @Operation(
+            summary = "Get all the metrics for a single agent",
+            description = "Get all the metrics for a single agent in the contact center."
+    )
+    @ApiResponse(
+            responseCode = "200",
+            description = "Metrics fetched successfully"
+    )
+    @GetMapping("/agents/{agent_id}")
+    public List<ConnectMetricDTO> getAgentMetrics(@PathVariable Long agent_id){
+        return metricService.getAgentMetrics(agent_id);
     }
 }

--- a/src/main/java/com/springboot/connectmate/dtos/Metric/ConnectMetricDTO.java
+++ b/src/main/java/com/springboot/connectmate/dtos/Metric/ConnectMetricDTO.java
@@ -1,0 +1,43 @@
+package com.springboot.connectmate.dtos.Metric;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Data;
+import java.math.BigDecimal;
+
+@Data
+@Schema(
+        name = "Metrics stored in the database",
+        description = "DTO for the stored metric"
+)
+public class ConnectMetricDTO {
+
+    @Schema(
+            description = "Id of the Metric",
+            example = "1"
+    )
+    private Long id;
+
+    @Schema(
+            description = "Code of the Metric",
+            example = "SL"
+    )
+    private String metric_info_code;
+
+    @Schema(
+            description = "Value of the metric",
+            example = "100"
+    )
+    private BigDecimal value;
+
+    @Schema(
+            description = "User Id of the Metric",
+            example = "1"
+    )
+    private Long agent_id;
+
+    @Schema(
+            description = "Queue Id of the Metric",
+            example = "1"
+    )
+    private Long queue_id;
+}

--- a/src/main/java/com/springboot/connectmate/models/ConnectMetric.java
+++ b/src/main/java/com/springboot/connectmate/models/ConnectMetric.java
@@ -1,0 +1,47 @@
+package com.springboot.connectmate.models;
+
+import com.springboot.connectmate.enums.MetricCategory;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+@Data // Lombok annotation to create all the getters, setters, equals, hash, and toString methods for us
+@AllArgsConstructor // Lombok annotation to create a constructor with all the arguments
+@NoArgsConstructor // Lombok annotation to create a constructor with no arguments
+
+@Entity
+@Table(name = "connect_metrics")
+public class ConnectMetric {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "metric_info_code")
+    private MetricCategory metricInfoCode;
+
+    @Column(name = "value", precision = 10, scale = 2)
+    private BigDecimal value;
+
+    @Column(name = "agent_id")
+    private Long agentId;
+
+    @Column(name = "queue_id")
+    private Long queueId;
+
+    @Column(name="date")
+    private LocalDateTime date = LocalDateTime.now();
+
+    @Column(name = "minimum_threshold", precision = 10, scale = 2)
+    private BigDecimal minimumThreshold;
+
+    @Column(name = "maximum_threshold", precision = 10, scale = 2)
+    private BigDecimal maximumThreshold;
+
+    @Column(name = "positive_upside")
+    private boolean positiveUpside;
+}

--- a/src/main/java/com/springboot/connectmate/repositories/MetricRepository.java
+++ b/src/main/java/com/springboot/connectmate/repositories/MetricRepository.java
@@ -1,7 +1,9 @@
 package com.springboot.connectmate.repositories;
 
 import com.springboot.connectmate.models.Metric;
+import jakarta.persistence.Tuple;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.jpa.repository.query.Procedure;
 
 import java.util.List;
@@ -9,4 +11,7 @@ import java.util.List;
 public interface MetricRepository extends JpaRepository<Metric, Long> {
     @Procedure("sp_get_contact_center_metrics")
     List<Object[]> getContactCenterMetrics();
+
+    @Query(value = "SELECT * FROM v_get_agent_metrics WHERE agent_id = :agentId", nativeQuery = true)
+    List<Tuple> getAgentMetrics(Long agentId);
 }

--- a/src/main/java/com/springboot/connectmate/services/MetricService.java
+++ b/src/main/java/com/springboot/connectmate/services/MetricService.java
@@ -1,5 +1,6 @@
 package com.springboot.connectmate.services;
 
+import com.springboot.connectmate.dtos.Metric.ConnectMetricDTO;
 import com.springboot.connectmate.dtos.Metric.MetricDTO;
 import com.springboot.connectmate.dtos.Metric.MetricDescriptionDTO;
 
@@ -8,4 +9,5 @@ import java.util.List;
 public interface MetricService {
     MetricDescriptionDTO getMetricDescriptionById(Long metricId);
     List<MetricDTO> getContactCenterMetrics();
+    List<ConnectMetricDTO> getAgentMetrics(Long agentId);
 }

--- a/src/main/java/com/springboot/connectmate/services/impl/MetricServiceImpl.java
+++ b/src/main/java/com/springboot/connectmate/services/impl/MetricServiceImpl.java
@@ -1,5 +1,6 @@
 package com.springboot.connectmate.services.impl;
 
+import com.springboot.connectmate.dtos.Metric.ConnectMetricDTO;
 import com.springboot.connectmate.dtos.Metric.MetricDTO;
 import com.springboot.connectmate.enums.MetricCategory;
 import com.springboot.connectmate.dtos.Metric.MetricDescriptionDTO;
@@ -7,6 +8,7 @@ import com.springboot.connectmate.exceptions.ResourceNotFoundException;
 import com.springboot.connectmate.models.Metric;
 import com.springboot.connectmate.repositories.MetricRepository;
 import com.springboot.connectmate.services.MetricService;
+import jakarta.persistence.Tuple;
 import org.modelmapper.ModelMapper;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
@@ -51,6 +53,22 @@ public class MetricServiceImpl implements MetricService {
                     dto.setCode(MetricCategory.valueOf((String) result[0]));
                     dto.setName((String) result[1]);
                     dto.setValue((BigDecimal) result[2]);
+                    return dto;
+                })
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    public List<ConnectMetricDTO> getAgentMetrics(Long agentId){
+        List<Tuple> results = metricRepository.getAgentMetrics(agentId);
+        return results.stream()
+                .map(result -> {
+                    ConnectMetricDTO dto = new ConnectMetricDTO();
+                    dto.setId(result.get("id", Long.class));
+                    dto.setMetric_info_code(String.valueOf(MetricCategory.valueOf(result.get("metric_info_code", String.class))));
+                    dto.setValue(result.get("value", BigDecimal.class));
+                    dto.setAgent_id(result.get("agent_id", Long.class));
+                    dto.setQueue_id(result.get("queue_id", Long.class));
                     return dto;
                 })
                 .collect(Collectors.toList());


### PR DESCRIPTION
IMPORTANT:
Este endpoint es el endpoint que usaremos para la pantalla del jueves. 
Esta **NO** es la versión final del endpoint, puesto que habrá que modificar la base de datos y los queries.
Se creó la tabla connect_metrics para este endpoint por el momento para cumplir con las necesidades de la semana.

Screenshots del endpoint 100% funcional:
<img width="959" alt="metrics_agents_1" src="https://github.com/Tec-de-Monterrey-Capstone-Project-2024/SpringBoot_Backend/assets/83442622/cc467ebe-aaea-46f1-8f6e-56d61a9afc1f">
<img width="959" alt="metrics_agents_2" src="https://github.com/Tec-de-Monterrey-Capstone-Project-2024/SpringBoot_Backend/assets/83442622/c2b5a701-6805-4ba6-ae0d-f890ccff327d">
<img width="958" alt="metrics_agents_3" src="https://github.com/Tec-de-Monterrey-Capstone-Project-2024/SpringBoot_Backend/assets/83442622/a724505b-42ff-4404-bd12-e88fe4be670f">
